### PR TITLE
Add overloaded  operators for BigInt types

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -742,6 +742,10 @@ proc `divmod` *(a, b: BigInt): tuple[q, r: BigInt] =
 #  var tmp = null
 #  division(tmp, x, y, z)
 
+proc `%%` *(a: BigInt, b: int32): BigInt = a mod b
+
+proc `%%` *(a, b: BigInt): BigInt = a mod b
+
 template optDivMod*{w = y div z; x = y mod z}(w,x,y,z: BigInt) =
   division(w, x, y, z)
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -60,3 +60,20 @@ test "off by one in division (https://github.com/def-/nim-bigints/issues/5)":
     var x = initBigInt("815915283247897734345611269596115894272000000000")
     var y = initBigInt("20000000000")
     check x div y == initBigInt("40795764162394886717280563479805794713")
+
+test "Mod operators":
+  block:
+    let
+      x = 10.initBigInt
+      y = 2.initBigInt
+      z = 3.initBigInt
+    check x %% y == 0.initBigInt
+    check x %% z == 1.initBigInt
+
+  block:
+    let
+      x = 10.initBigInt
+      y = 2'i32
+      z = 3'i32
+    check x %% y == 0.initBigInt
+    check x %% z == 1.initBigInt


### PR DESCRIPTION
Just making it easier to make assumptions about bigint library behavior based on normal Nim behavior