### PR TITLE
Add ability to call initBigInt on an existing BigInt

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -57,6 +57,9 @@ proc initBigInt*(val: uint64): BigInt =
   else:
     result = uint32(val).initBigInt
 
+proc initBigInt*(val: BigInt): BigInt =
+  result = val
+
 const null = initBigInt(0)
 const one = initBigInt(1)
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -22,6 +22,10 @@ test "initBigInt":
   let g = (1'u64 shl 63).initBigInt
   check $g == $(1'u64 shl 63)
 
+  let h = 1234567.initBigInt
+  let i = h.initBigInt
+  check $h == $i
+
 test "range of bigint (https://github.com/def-/nim-bigints/issues/1)":
   let two = 2.initBigInt
   let n = "123".initBigInt


### PR DESCRIPTION
Makes it easier to write generic code if we can get an initBigInt operation that does nothing on an existing BigInt