### PR TITLE
Fix int and BigInt comparison like 2 < 100.initBigInt

### DIFF
--- a/src/bigints.nim
+++ b/src/bigints.nim
@@ -150,7 +150,7 @@ proc cmp*(a: BigInt, b: int32): int64 =
     if b <= 0:
       return 1
     else:
-      return unsignedCmp(b, a)
+      return unsignedCmp(a, b)
 
 proc cmp*(a: int32, b: BigInt): int64 = -cmp(b, a)
 

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -238,3 +238,18 @@ test "operations with self (e.g. https://github.com/def-/nim-bigints/issues/27)"
   a = a + b; check a == b  # this does not fail here, but it failed if tested separately: nim c -r tests/tissue_27
   x *= x; check x == one
   b = b * 2.int32
+
+test "simple comparisons":
+  var
+    hundred = 100.initBigInt
+    fifty = 50.initBigInt
+
+  check hundred > fifty
+  check fifty < hundred
+  check hundred != fifty
+
+  check 100 > fifty
+  check hundred > 50
+  check fifty < 100
+  check 50 < hundred
+


### PR DESCRIPTION
The following check used to fail: `check 2 < 100.initBigInt`.

I think this comes down to a basic typo in one line. I also added some simple test cases for this.